### PR TITLE
Limit maximum workers and rate limit the start of each

### DIFF
--- a/src/treewalker_dispatcher.erl
+++ b/src/treewalker_dispatcher.erl
@@ -18,12 +18,15 @@
 
 -record(state, {config :: config(),
                 retry_policy :: retry_policy(),
+                max_concurrent_worker :: pos_integer(),
+                pending_requests = queue:new() :: queue:queue({reference(), pid(), url()}),
                 callers_by_workers_pids = #{} :: #{pid() := {reference(), pid()}}}).
 
 -define(VIA_GPROC(Id), {via, gproc, {n, l, Id}}).
 -define(MIN_RETRY_DELAY, 1000).
 -define(MAX_RETRY_DELAY, 5 * 60000).
 -define(MAX_RETRIES, 5).
+-define(MAX_CONCURRENT_WORKERS, 10).
 
 -type url() :: treewalker_page:url().
 -type retry_policy() :: treewalker_worker:retry_policy().
@@ -51,14 +54,20 @@ init([Config]) ->
     MinDelay = application:get_env(treewalker, min_retry_delay, ?MIN_RETRY_DELAY),
     MaxDelay = application:get_env(treewalker, max_retry_delay, ?MAX_RETRY_DELAY),
     MaxRetry = application:get_env(treewalker, max_retries, ?MAX_RETRIES),
+    MaxConcurrentWorker = application:get_env(treewalker,
+                                              max_concurrent_worker,
+                                              ?MAX_CONCURRENT_WORKERS),
     RetryPolicy = #retry_policy{max_retry = MaxRetry, min_delay = MinDelay, max_delay = MaxDelay},
-    {ok, #state{config = Config, retry_policy = RetryPolicy}}.
+    {ok, #state{config = Config,
+                retry_policy = RetryPolicy,
+                max_concurrent_worker = MaxConcurrentWorker}}.
 
-handle_call({request, Caller, Url}, _From, State) ->
-    ?LOG_INFO(#{what => request_received, requester => Caller, status => start, url => Url}),
+handle_call({request, Caller, Url}, _, State=#state{pending_requests = PendingRequests}) ->
+    ?LOG_INFO(#{what => request_received, requester => Caller, status => queuing, url => Url}),
+    After = rand:uniform(5),
+    erlang:send_after(After * 1000, self(), start),
     Ref = make_ref(),
-    UpdatedState = try_start_worker(Caller, Ref, Url, State),
-    {reply, Ref, UpdatedState};
+    {reply, Ref, State#state{pending_requests = queue:in({Ref, Caller, Url}, PendingRequests)}};
 
 handle_call(_Request, _From, State) ->
     {reply, ok, State}.
@@ -66,12 +75,26 @@ handle_call(_Request, _From, State) ->
 handle_cast(_Msg, State) ->
     {noreply, State}.
 
+handle_info(start, State=#state{callers_by_workers_pids = Workers,
+                                max_concurrent_worker = MaxConcurrentWorker})
+  when map_size(Workers) < MaxConcurrentWorker ->
+    ?LOG_INFO(#{what => worker_start, status => start, workers_amount => map_size(Workers)}),
+    try_start_pending_requests(State);
+handle_info(start, State) ->
+    {noreply, State};
+
 handle_info({treewalker_worker, Pid, Reason}, State) ->
     ?LOG_DEBUG(#{what => worker_response, pid => Pid}),
-    maybe_response_to_caller(Reason, Pid, State);
+    UpdatedState = maybe_response_to_caller(Reason, Pid, State),
+    After = rand:uniform(5),
+    erlang:send_after(After * 1000, self(), start),
+    {noreply, UpdatedState};
 handle_info({'EXIT', Pid, Reason}, State) ->
     ?LOG_DEBUG(#{what => worker_exit, pid => Pid, reason => Reason}),
-    maybe_response_to_caller({error, Reason}, Pid, State);
+    UpdatedState = maybe_response_to_caller({error, Reason}, Pid, State),
+    After = rand:uniform(5),
+    erlang:send_after(After * 1000, self(), start),
+    {noreply, UpdatedState};
 
 handle_info(Message, State) ->
     ?LOG_WARNING(#{what => unexpected_message, message => Message}),
@@ -102,7 +125,16 @@ maybe_response_to_caller(Response, Pid, State) ->
     case maps:take(Pid, State#state.callers_by_workers_pids) of
         {{Ref, Caller}, CallersByWorkersPids} ->
             Caller ! {?MODULE, Ref, Response},
-            {noreply, State#state{callers_by_workers_pids = CallersByWorkersPids}};
+            State#state{callers_by_workers_pids = CallersByWorkersPids};
         error ->
+            State
+    end.
+
+try_start_pending_requests(State=#state{pending_requests = PendingRequests}) ->
+    case queue:out(PendingRequests) of
+        {{value, {Ref, Caller, Url}}, UpdatedRequests} ->
+            UpdatedState = State#state{pending_requests = UpdatedRequests},
+            {noreply, try_start_worker(Caller, Ref, Url, UpdatedState)};
+        {empty, _} ->
             {noreply, State}
     end.

--- a/src/treewalker_rate_limit.erl
+++ b/src/treewalker_rate_limit.erl
@@ -1,0 +1,18 @@
+-module(treewalker_rate_limit).
+
+%% API
+-export([delay/1]).
+
+-define(MILLISECONDS_PER_SECOND, 1000).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+-spec delay(MaxDelayInSeconds :: pos_integer()) -> ComputedDelayInMilliseconds :: pos_integer().
+delay(MaxDelayInSeconds) ->
+    rand:uniform(MaxDelayInSeconds) * ?MILLISECONDS_PER_SECOND.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================

--- a/test/treewalker_dispatcher_SUITE.erl
+++ b/test/treewalker_dispatcher_SUITE.erl
@@ -25,6 +25,7 @@ init_per_suite(Config) ->
 
     {ok, Applications} = application:ensure_all_started(gproc),
     meck:new(treewalker_worker, [no_link]),
+    meck:new(treewalker_rate_limit, [no_link]),
     [{applications, Applications} | Config].
 
 end_per_suite(Config) ->
@@ -34,6 +35,7 @@ end_per_suite(Config) ->
 
 init_per_testcase(_Name, Config) ->
     meck:reset(treewalker_worker),
+    meck:reset(treewalker_rate_limit),
     AConfig = treewalker_crawler_config:init(),
 
     {ok, Pid} = treewalker_dispatcher:start_link(?AN_ID, AConfig),
@@ -43,6 +45,7 @@ init_per_testcase(_Name, Config) ->
                         Pid ! {treewalker_worker, WorkerPid, {ok, ?A_BODY}},
                         {ok, WorkerPid}
                 end),
+    meck:expect(treewalker_rate_limit, delay, [{['_'], 100}]),
     Config.
 
 end_per_testcase(_Name, Config) ->

--- a/test/treewalker_fetcher_SUITE.erl
+++ b/test/treewalker_fetcher_SUITE.erl
@@ -1,0 +1,51 @@
+-module(treewalker_fetcher_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-compile(nowarn_export_all).
+-compile(export_all).
+
+-define(A_CODE, 200).
+-define(A_BODY, <<"a body">>).
+-define(A_USER_AGENT, <<"user-agent">>).
+-define(AN_URL, <<"http://anurl.com">>).
+
+all() ->
+    [
+     can_handle_successful_request,
+     return_error_on_request_error
+    ].
+
+init_per_suite(Config) ->
+    meck:new(hackney, [no_link]),
+    Config.
+
+end_per_suite(Config) ->
+    meck:unload(),
+    Config.
+
+init_per_testcase(_Name, Config) ->
+    meck:reset(hackney),
+
+    meck:expect(hackney, request, [{['_', '_', '_', '_', '_'], {ok, ?A_CODE, [], ?A_BODY}}]),
+    Config.
+
+end_per_testcase(_Name, Config) ->
+    Config.
+
+can_handle_successful_request() ->
+    [{doc, "When making a successful request, then returns body and code."}].
+can_handle_successful_request(_Config) ->
+    ?assertMatch({ok, {?A_CODE, ?A_BODY}}, treewalker_fetcher:request(?AN_URL, ?A_USER_AGENT, [])).
+
+return_error_on_request_error() ->
+    [{doc, "When making a failed request, then returns an error."}].
+return_error_on_request_error(_Config) ->
+    meck:expect(hackney, request, [{['_', '_', '_', '_', '_'], {error, nxdomain}}]),
+
+    ?assertMatch({error, _}, treewalker_fetcher:request(?AN_URL, ?A_USER_AGENT, [])).
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================


### PR DESCRIPTION
Now, the maximum number of concurrent workers can be configured. Also, they will be started according to an uniform distribution.

This is for issues #3 and #4.